### PR TITLE
Use query context example

### DIFF
--- a/src/ApolloProviderClient.js
+++ b/src/ApolloProviderClient.js
@@ -11,6 +11,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 
 const GITHUB_BASE_URL = 'https://api.github.com/graphql';
 
+// eslint-disable-next-line no-unused-vars
 const ApolloProviderClient = ({ children, onAlert }) => {
   const httpLink = new HttpLink({
     uri: GITHUB_BASE_URL,
@@ -32,9 +33,9 @@ const ApolloProviderClient = ({ children, onAlert }) => {
       console.log(`[Network error]: ${networkError}`);
     }
 
-    if (graphQLErrors || networkError) {
-      onAlert('Something Went Wrong!');
-    }
+    // if (graphQLErrors || networkError) {
+    //   onAlert('Something Went Wrong!');
+    // }
   });
 
   const link = ApolloLink.from([errorLink, httpLink]);

--- a/src/ApolloProviderClient.js
+++ b/src/ApolloProviderClient.js
@@ -1,9 +1,9 @@
-/* eslint-disable no-console */
-import React, { memo } from 'react';
-import PropTypes from 'prop-types';
+// /* eslint-disable no-console */
+// import React, { memo } from 'react';
+// import PropTypes from 'prop-types';
 
 import { ApolloClient } from 'apollo-client';
-import { ApolloProvider } from 'react-apollo';
+// import { ApolloProvider } from 'react-apollo';
 import { ApolloLink } from 'apollo-link';
 import { HttpLink } from 'apollo-link-http';
 import { onError } from 'apollo-link-error';
@@ -11,62 +11,32 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 
 const GITHUB_BASE_URL = 'https://api.github.com/graphql';
 
-// eslint-disable-next-line no-unused-vars
-const ApolloProviderClient = ({ children, onAlert }) => {
-  const httpLink = new HttpLink({
-    uri: GITHUB_BASE_URL,
-    headers: {
-      authorization: `Bearer ${
-        process.env.REACT_APP_GITHUB_PERSONAL_ACCESS_TOKEN
-      }`,
-    },
-  });
+const httpLink = new HttpLink({
+  uri: GITHUB_BASE_URL,
+  headers: {
+    authorization: `Bearer ${
+      process.env.REACT_APP_GITHUB_PERSONAL_ACCESS_TOKEN
+    }`,
+  },
+});
 
-  const errorLink = onError(({ graphQLErrors, networkError }) => {
-    if (graphQLErrors) {
-      graphQLErrors.map(({ message, locations, path }) => console.log(
-        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-      ));
-    }
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors) {
+    graphQLErrors.map(({ message, locations, path }) => console.log(
+      `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+    ));
+  }
 
-    if (networkError) {
-      console.log(`[Network error]: ${networkError}`);
-    }
+  if (networkError) {
+    console.log(`[Network error]: ${networkError}`);
+  }
+});
 
-    // if (graphQLErrors || networkError) {
-    //   onAlert('Something Went Wrong!');
-    // }
-  });
+const link = ApolloLink.from([errorLink, httpLink]);
 
-  const link = ApolloLink.from([errorLink, httpLink]);
+const cache = new InMemoryCache();
 
-  const cache = new InMemoryCache();
-
-  const client = new ApolloClient({
-    link,
-    cache,
-  });
-
-  return (
-    <ApolloProvider client={client}>
-      {children}
-    </ApolloProvider>
-  );
-};
-
-ApolloProviderClient.propTypes = {
-  children: PropTypes.element,
-  onAlert: PropTypes.func,
-};
-
-/*
-  So this is the most dangerous part of the solution
-  ApolloProviderClient will never re-render. If it is placed
-  at the highest level of your tree it shouldn’t be a problem, because
-  its children are the whole app and its onAlert prop-func will never change
-  This could cause issues if you use React.Portals on root... and
-  anything else complicated.
-*/
-const deepEqualityCheck = () => true;
-
-export default memo(ApolloProviderClient, deepEqualityCheck);
+export default new ApolloClient({
+  link,
+  cache,
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
-import { useQuery } from '@apollo/react-hooks';
+import { useQuery } from './hooks';
 import { MY_REPOSITORY_LIST, GET_EMAIL, BAD_EMAIL } from './Queries';
 
 const BodyWidth = styled.div`

--- a/src/alert/AlertContextProvider.js
+++ b/src/alert/AlertContextProvider.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+// import { useTimedBoolean } from '../hooks';
+
+export const AlertContext = React.createContext();
+
+const AlertContextProvider = ({ children }) => {
+  const [visible, setVisibility] = useState(false);
+
+  const toggleVisibility = () => {
+    setVisibility(true);
+  };
+
+  return (
+    <>
+      {visible && <div>ALEEEERRRRTTTTT</div>}
+      <AlertContext.Provider value={{ toggleTimedAlert: toggleVisibility }}>
+        {children}
+      </AlertContext.Provider>
+    </>
+  );
+};
+
+AlertContextProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export default AlertContextProvider;

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useBoolean } from './useBoolean';
 export { default as useTimedBoolean } from './useTimedBoolean';
+export { default as useQuery } from './useQuery';

--- a/src/hooks/useQuery.js
+++ b/src/hooks/useQuery.js
@@ -1,0 +1,10 @@
+import { useQuery } from '@apollo/react-hooks';
+
+const useQueryContainer = (props) => {
+  const response = useQuery(props);
+  const { error } = response;
+  if (error) { console.log('there was an error'); }
+  return response;
+};
+
+export default useQueryContainer;

--- a/src/hooks/useQuery.js
+++ b/src/hooks/useQuery.js
@@ -1,9 +1,13 @@
+import { useContext } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 
+import { AlertContext } from '../alert/AlertContextProvider';
+
 const useQueryContainer = (props) => {
+  const { toggleTimedAlert } = useContext(AlertContext);
   const response = useQuery(props);
   const { error } = response;
-  if (error) { console.log('there was an error'); }
+  if (error) { toggleTimedAlert(); }
   return response;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,16 @@
-/* eslint-disable no-console */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ApolloProviderClient from './ApolloProviderClient';
-import AlertWrapper from './alert/AlertWrapper';
+import { ApolloProvider } from 'react-apollo';
+import client from './ApolloProviderClient';
+import AlertContextProvider from './alert/AlertContextProvider';
 
 import App from './App';
 
 ReactDOM.render(
-  <AlertWrapper>
-    {({ onAlert }) => (
-      <ApolloProviderClient onAlert={onAlert}>
-        <App />
-      </ApolloProviderClient>
-    )}
-  </AlertWrapper>,
+  <AlertContextProvider>
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
+  </AlertContextProvider>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
Revert the Old Error Way (hijacking apollo client with a render prop + problematic memoization) and Implement the new safer way (using context and hijacking useQuery import)